### PR TITLE
Cleanup backend: Decoupling Auth and posts

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,6 +15,7 @@
     "ethers": "^4.0.45",
     "express": "^4.17.1",
     "knex": "^0.20.10",
+    "nodemon": "^2.0.2",
     "objection": "^2.1.3",
     "semaphore-auth-contracts": "file:../contracts",
     "sqlite3": "^4.1.1"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "nodemon index.js",
     "test": "ava --timeout=1m"
   },
   "keywords": [],
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "ava": "^3.4.0",
+    "nodemon": "^2.0.2",
     "supertest": "^4.0.2",
     "yarn": "^1.22.0"
   }

--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -25,29 +25,19 @@ app.get('/posts', async (req, res) => {
   res.json({ posts })
 })
 
-app.post('/posts/new', requireSemaphoreAuth, async (req, res) => {
-  const {
-    root,
-    nullifierHash,
-    signalHash,
-    externalNullifier,
-    externalNullifierStr
-  } = req.authData
-  await Post.query()
+app.post('/posts/new', requireSemaphoreAuth, async (req, res, next) => {
+  const post = await Post.query()
     .insert({
       postBody: req.body.postBody,
-      proof: req.body.proof,
-      root,
-      nullifierHash,
-      signalHash,
-      externalNullifier,
-      externalNullifierStr
+      semaphoreLogId: req.semaphoreLogId
     })
-    .catch(err => {
-      console.error(err)
-      res.status(500).end(err.toString())
-    })
-  res.send('OK')
+    .catch(next)
+  res.send(`Your article is published! Article id: ${post.id}`)
+})
+
+app.use(function (err, req, res, next) {
+  console.error(err.stack)
+  res.status(500).send(err.toString())
 })
 
 module.exports = app

--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -1,114 +1,14 @@
 const express = require('express')
 const app = express()
-const ethers = require('ethers')
-const libsemaphore = require('libsemaphore')
-const fs = require('fs')
-const snarkjs = require('snarkjs')
-const { Model } = require('objection')
-const { VERIFYING_KEY_PATH } = require('semaphore-auth-contracts/constants')
-const { semaphoreContract } = require('semaphore-auth-contracts/src/contracts')
-const {
-  EpochbasedExternalNullifier
-} = require('semaphore-auth-contracts/lib/externalNullifier')
-const path = require('path')
+
 const configs = require('./configs')
-
-const knex = require('knex')({
-  client: 'sqlite3',
-  connection: {
-    filename: './mydb.sqlite'
-  }
-})
-
-Model.knex(knex)
-
-class Post extends Model {
-  static get tableName () {
-    return 'posts'
-  }
-}
-
-async function createSchema () {
-  if (await knex.schema.hasTable('posts')) {
-    return
-  }
-
-  await knex.schema.createTable('posts', table => {
-    table.increments('id').primary()
-    table.string('postBody')
-
-    table.string('proof')
-
-    table.string('root')
-    table.string('nullifierHash')
-    table.string('signalHash')
-    table.string('externalNullifier')
-    table.string('externalNullifierStr')
-
-    table
-      .dateTime('createdAt')
-      .notNullable()
-      .defaultTo(knex.fn.now())
-  })
-}
+const { createSchema, Post } = require('./schema')
+const { requireSemaphoreAuth } = require('./authentication')
 
 createSchema()
 
-function validateExternalNullifierMatch (actual, externalNullifierStr) {
-  const expected = snarkjs.bigInt(
-    libsemaphore.genExternalNullifier(externalNullifierStr)
-  )
-  if (expected !== actual) {
-    throw Error(
-      `Illegal externalNullifier: expect "${expected}" (${externalNullifierStr}), got "${actual}"`
-    )
-  }
-}
-
-function validateSignalHash (postBody, actual) {
-  const signalStr = ethers.utils.hashMessage(postBody)
-  const expected = libsemaphore.keccak256HexToBigInt(
-    ethers.utils.hexlify(ethers.utils.toUtf8Bytes(signalStr))
-  )
-  if (actual !== expected) {
-    throw Error(`Expected signalHash ${expected}, got ${actual}`)
-  }
-}
-async function validateNullifierNotSeen (nullifierHash) {
-  const results = await Post.query()
-    .select('nullifierHash', 'externalNullifierStr', 'id')
-    .where('nullifierHash', nullifierHash.toString())
-    .catch(console.error)
-
-  if (results.length > 0) {
-    const post = results[0]
-    throw new Error(
-      `Spam post: nullifierHash (${nullifierHash}) has been seen before for the same external nullifier "${post.externalNullifierStr}" in post id ${post.id}`
-    )
-  }
-}
-async function validateInRootHistory (root) {
-  const provider = new ethers.providers.JsonRpcProvider()
-  const semaphore = semaphoreContract(provider, configs.SEMAPHORE_ADDRESS)
-
-  const isInRootHistory = await semaphore.isInRootHistory(
-    libsemaphore.stringifyBigInts(root)
-  )
-  if (!isInRootHistory) throw Error(`Root (${root.toString()}) not in history`)
-}
-
-async function validateProof (proof, publicSignals) {
-  const verifyingKey = libsemaphore.parseVerifyingKeyJson(
-    fs.readFileSync(VERIFYING_KEY_PATH).toString()
-  )
-  const isValid = libsemaphore.verifyProof(verifyingKey, proof, publicSignals)
-  if (!isValid) throw Error('Invalid Proof')
-}
-
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
-
-app.use('/', express.static(path.join(__dirname, '../../frontend/dist')))
 
 app.get('/info', (req, res) => {
   res.json({
@@ -125,53 +25,28 @@ app.get('/posts', async (req, res) => {
   res.json({ posts })
 })
 
-const newPostExternalNullifierGen = new EpochbasedExternalNullifier(
-  configs.SERVER_NAME,
-  '/posts/new',
-  300 * 1000 // rate limit to 30 seconds
-)
-
-app.post('/posts/new', async (req, res) => {
-  const rawProof = req.body.proof
-  const parsedProof = libsemaphore.unstringifyBigInts(JSON.parse(rawProof))
-  const parsedPublicSignals = libsemaphore.unstringifyBigInts(
-    JSON.parse(req.body.publicSignals)
-  )
-  const [
+app.post('/posts/new', requireSemaphoreAuth, async (req, res) => {
+  const {
     root,
     nullifierHash,
     signalHash,
-    externalNullifier
-  ] = parsedPublicSignals
-  const postBody = req.body.postBody
-
-  const expectedExternalNullifierStr = newPostExternalNullifierGen.toString()
-
-  try {
-    validateExternalNullifierMatch(
-      externalNullifier,
-      expectedExternalNullifierStr
-    )
-    validateSignalHash(postBody, signalHash)
-    // await validateInRootHistory(root)
-    await validateNullifierNotSeen(nullifierHash)
-    await validateProof(parsedProof, parsedPublicSignals)
-  } catch (err) {
-    res.status(400).end(`Bad Request:${err.toString()}`)
-    return
-  }
-
+    externalNullifier,
+    externalNullifierStr
+  } = req.authData
   await Post.query()
     .insert({
-      postBody,
-      proof: rawProof,
+      postBody: req.body.postBody,
+      proof: req.body.proof,
       root,
-      nullifierHash: nullifierHash.toString(),
+      nullifierHash,
       signalHash,
       externalNullifier,
-      externalNullifierStr: expectedExternalNullifierStr
+      externalNullifierStr
     })
-    .catch(console.error)
+    .catch(err => {
+      console.error(err)
+      res.status(500).end(err.toString())
+    })
   res.send('OK')
 })
 

--- a/packages/backend/src/authentication.js
+++ b/packages/backend/src/authentication.js
@@ -1,0 +1,65 @@
+const {
+  validateExternalNullifierMatch,
+  validateSignalHash,
+  validateNullifierNotSeen,
+  validateInRootHistory,
+  validateProof
+} = require('./validation')
+
+const configs = require('./configs')
+
+const {
+  EpochbasedExternalNullifier
+} = require('semaphore-auth-contracts/lib/externalNullifier')
+
+const { unstringifyBigInts } = require('libsemaphore')
+
+const newPostExternalNullifierGen = new EpochbasedExternalNullifier(
+  configs.SERVER_NAME,
+  '/posts/new',
+  300 * 1000 // rate limit to 30 seconds
+)
+
+// Do semaphore authentication as a middleware
+const requireSemaphoreAuth = async (req, res, next) => {
+  const rawProof = req.body.proof
+  const parsedProof = unstringifyBigInts(JSON.parse(rawProof))
+  const parsedPublicSignals = unstringifyBigInts(
+    JSON.parse(req.body.publicSignals)
+  )
+  const [
+    root,
+    nullifierHash,
+    signalHash,
+    externalNullifier
+  ] = parsedPublicSignals
+  const postBody = req.body.postBody
+
+  const expectedExternalNullifierStr = newPostExternalNullifierGen.toString()
+
+  try {
+    validateExternalNullifierMatch(
+      externalNullifier,
+      expectedExternalNullifierStr
+    )
+    validateSignalHash(postBody, signalHash)
+    // await validateInRootHistory(root)
+    await validateNullifierNotSeen(nullifierHash)
+    await validateProof(parsedProof, parsedPublicSignals)
+  } catch (err) {
+    console.log(err)
+    res.status(400).end(`Bad Request:${err.toString()}`)
+    return
+  }
+
+  req.authData = {
+    root,
+    nullifierHash: nullifierHash.toString(),
+    signalHash,
+    externalNullifier,
+    externalNullifierStr: expectedExternalNullifierStr
+  }
+  next()
+}
+
+module.exports = { requireSemaphoreAuth }

--- a/packages/backend/src/schema.js
+++ b/packages/backend/src/schema.js
@@ -13,6 +13,23 @@ class Post extends Model {
   static get tableName () {
     return 'posts'
   }
+  static get relationMappings () {
+    return {
+      authData: {
+        relation: Model.HasOneRelation,
+        modelClass: SemaphoreLog,
+        join: {
+          from: 'posts.semaphoreLogId',
+          to: 'semaphore_log.id'
+        }
+      }
+    }
+  }
+}
+class SemaphoreLog extends Model {
+  static get tableName () {
+    return 'semaphore_log'
+  }
 }
 
 async function createSchema () {
@@ -23,14 +40,20 @@ async function createSchema () {
   await knex.schema.createTable('posts', table => {
     table.increments('id').primary()
     table.string('postBody')
+    table.integer('semaphoreLogId')
+    table
+      .dateTime('createdAt')
+      .notNullable()
+      .defaultTo(knex.fn.now())
+  })
 
-    table.string('proof')
-
+  await knex.schema.createTable('semaphore_log', table => {
+    table.increments('id').primary()
     table.string('root')
     table.string('nullifierHash')
     table.string('signalHash')
-    table.string('externalNullifier')
     table.string('externalNullifierStr')
+    table.string('proof')
 
     table
       .dateTime('createdAt')
@@ -39,4 +62,4 @@ async function createSchema () {
   })
 }
 
-module.exports = { createSchema , Post}
+module.exports = { createSchema, Post, SemaphoreLog }

--- a/packages/backend/src/schema.js
+++ b/packages/backend/src/schema.js
@@ -1,0 +1,42 @@
+const { Model } = require('objection')
+
+const knex = require('knex')({
+  client: 'sqlite3',
+  connection: {
+    filename: './mydb.sqlite'
+  }
+})
+
+Model.knex(knex)
+
+class Post extends Model {
+  static get tableName () {
+    return 'posts'
+  }
+}
+
+async function createSchema () {
+  if (await knex.schema.hasTable('posts')) {
+    return
+  }
+
+  await knex.schema.createTable('posts', table => {
+    table.increments('id').primary()
+    table.string('postBody')
+
+    table.string('proof')
+
+    table.string('root')
+    table.string('nullifierHash')
+    table.string('signalHash')
+    table.string('externalNullifier')
+    table.string('externalNullifierStr')
+
+    table
+      .dateTime('createdAt')
+      .notNullable()
+      .defaultTo(knex.fn.now())
+  })
+}
+
+module.exports = { createSchema , Post}

--- a/packages/backend/src/validation.js
+++ b/packages/backend/src/validation.js
@@ -14,7 +14,7 @@ const {
   verifyProof
 } = require('libsemaphore')
 
-const { Post } = require('./schema')
+const { SemaphoreLog } = require('./schema')
 
 function validateExternalNullifierMatch (actual, externalNullifierStr) {
   const expected = snarkjs.bigInt(genExternalNullifier(externalNullifierStr))
@@ -25,8 +25,8 @@ function validateExternalNullifierMatch (actual, externalNullifierStr) {
   }
 }
 
-function validateSignalHash (postBody, actual) {
-  const signalStr = ethers.utils.hashMessage(postBody)
+function validateSignalHash (content, actual) {
+  const signalStr = ethers.utils.hashMessage(content)
   const expected = keccak256HexToBigInt(
     ethers.utils.hexlify(ethers.utils.toUtf8Bytes(signalStr))
   )
@@ -35,15 +35,15 @@ function validateSignalHash (postBody, actual) {
   }
 }
 async function validateNullifierNotSeen (nullifierHash) {
-  const results = await Post.query()
+  const results = await SemaphoreLog.query()
     .select('nullifierHash', 'externalNullifierStr', 'id')
     .where('nullifierHash', nullifierHash.toString())
     .catch(console.error)
 
   if (results.length > 0) {
-    const post = results[0]
+    const log = results[0]
     throw new Error(
-      `Spam post: nullifierHash (${nullifierHash}) has been seen before for the same external nullifier "${post.externalNullifierStr}" in post id ${post.id}`
+      `nullifierHash (${nullifierHash}) has been seen before for the same external nullifier "${log.externalNullifierStr}"`
     )
   }
 }

--- a/packages/backend/src/validation.js
+++ b/packages/backend/src/validation.js
@@ -1,0 +1,74 @@
+const fs = require('fs')
+const snarkjs = require('snarkjs')
+
+const { VERIFYING_KEY_PATH } = require('semaphore-auth-contracts/constants')
+const { semaphoreContract } = require('semaphore-auth-contracts/src/contracts')
+
+const ethers = require('ethers')
+
+const {
+  genExternalNullifier,
+  keccak256HexToBigInt,
+  stringifyBigInts,
+  parseVerifyingKeyJson,
+  verifyProof
+} = require('libsemaphore')
+
+const { Post } = require('./schema')
+
+function validateExternalNullifierMatch (actual, externalNullifierStr) {
+  const expected = snarkjs.bigInt(genExternalNullifier(externalNullifierStr))
+  if (expected !== actual) {
+    throw Error(
+      `Illegal externalNullifier: expect "${expected}" (${externalNullifierStr}), got "${actual}"`
+    )
+  }
+}
+
+function validateSignalHash (postBody, actual) {
+  const signalStr = ethers.utils.hashMessage(postBody)
+  const expected = keccak256HexToBigInt(
+    ethers.utils.hexlify(ethers.utils.toUtf8Bytes(signalStr))
+  )
+  if (actual !== expected) {
+    throw Error(`Expected signalHash ${expected}, got ${actual}`)
+  }
+}
+async function validateNullifierNotSeen (nullifierHash) {
+  const results = await Post.query()
+    .select('nullifierHash', 'externalNullifierStr', 'id')
+    .where('nullifierHash', nullifierHash.toString())
+    .catch(console.error)
+
+  if (results.length > 0) {
+    const post = results[0]
+    throw new Error(
+      `Spam post: nullifierHash (${nullifierHash}) has been seen before for the same external nullifier "${post.externalNullifierStr}" in post id ${post.id}`
+    )
+  }
+}
+async function validateInRootHistory (root) {
+  const provider = new ethers.providers.JsonRpcProvider()
+  const semaphore = semaphoreContract(provider, configs.SEMAPHORE_ADDRESS)
+
+  const isInRootHistory = await semaphore.isInRootHistory(
+    stringifyBigInts(root)
+  )
+  if (!isInRootHistory) throw Error(`Root (${root.toString()}) not in history`)
+}
+
+async function validateProof (proof, publicSignals) {
+  const verifyingKey = parseVerifyingKeyJson(
+    fs.readFileSync(VERIFYING_KEY_PATH).toString()
+  )
+  const isValid = verifyProof(verifyingKey, proof, publicSignals)
+  if (!isValid) throw Error('Invalid Proof')
+}
+
+module.exports = {
+  validateExternalNullifierMatch,
+  validateSignalHash,
+  validateNullifierNotSeen,
+  validateInRootHistory,
+  validateProof
+}

--- a/packages/backend/test/backend.test.js
+++ b/packages/backend/test/backend.test.js
@@ -99,7 +99,7 @@ test('should post a new post', async t => {
     .set('Accept', 'application/json')
     .expect(200)
     .then(res => {
-      t.is(res.text, 'OK')
+      t.true(res.text.includes('Your article is published!'))
     })
 
   await request(app)

--- a/packages/cli/posts.js
+++ b/packages/cli/posts.js
@@ -98,6 +98,8 @@ const viewPostHandler = async () => {
   const posts = await fetch(new URL('./posts', hostInfo.get().hostUrl))
     .then(res => res.json())
     .then(result => result.posts)
+
+  console.clear()
   const response = await prompts({
     type: 'select',
     name: 'value',
@@ -120,13 +122,13 @@ const newPostExternalNullifierGen = new EpochbasedExternalNullifier(
 )
 
 const newPostHandler = async argv => {
+  console.clear()
   const articlePath = argv.article
   const article = fs
     .readFileSync(path.join(process.cwd(), articlePath))
     .toString()
 
   const signalStr = ethers.utils.hashMessage(article)
-  console.info(signalStr)
 
   const externalNullifierStr = newPostExternalNullifierGen.toString()
   console.info('Using externalNullifierStr as:', externalNullifierStr)

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,7 +8,8 @@
     "build_verifier": "rm semaphore/semaphorejs/contracts/verifier.sol && npx snarkjs generateverifier --vk semaphore/semaphorejs/build/verification_key.json -v semaphore/semaphorejs/contracts/verifier.sol",
     "deploy": "node ./scripts/deploy.js --verbose",
     "test": "ava",
-    "copyABIs": "node ./scripts/copyABIs.js"
+    "copyABIs": "node ./scripts/copyABIs.js",
+    "ganache": "ganache-cli -a 10 -m='candy maple cake sugar pudding cream honey rich smooth crumble sweet treat' --gasLimit=8800000 --port 8545 -i 1234"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
### What's wrong

- All backend logics are squeezed in app.js
- The Semaphore auth logic is coupled with posts. This makes applying Semaphore to other new data models hard. Eventually, we want the SemaphoreAuth to be a tool that's independent to use cases.

### How is it fixed

- Tear down app.js into different components.
- Make a SemaphoreLog

![](https://i.imgur.com/yBs0GSV.png)
