### PR TITLE
Fix download assets

### DIFF
--- a/packages/contracts/constants.js
+++ b/packages/contracts/constants.js
@@ -6,12 +6,13 @@ module.exports = {
 
   // The circuits, proving key, verification key, and semaphore tree depth are interdependent
   SEMAPHORE_TREE_DEPTH: 20, // This number depends on the circuit we use.
-  CIRCUIT_URL: 'https://www.dropbox.com/s/3gzxjibqgb6ke13/circuit.json?dl=1',
+  CIRCUIT_URL:
+    'https://dl.dropboxusercontent.com/s/3gzxjibqgb6ke13/circuit.json?dl=1',
   CIRCUIT_CACHE_PATH: path.join(__dirname, './cache/circuit.json'),
   PROVING_KEY_URL:
-    'https://www.dropbox.com/s/qjlu6v125g7jkcq/proving_key.bin?dl=1',
+    'https://dl.dropboxusercontent.com/s/qjlu6v125g7jkcq/proving_key.bin?dl=1',
   PROVING_KEY_CACHE_PATH: path.join(__dirname, './cache/proving_key.bin'),
   // verification_key.json is downloaded from
-  // https://www.dropbox.com/s/rwjwu31c7pzhsth/verification_key.json?dl=1
+  // https://dl.dropboxusercontent.com/s/rwjwu31c7pzhsth/verification_key.json?dl=1
   VERIFYING_KEY_PATH: path.join(__dirname, './assets/verification_key.json')
 }

--- a/packages/frontend/src/components/download_snarks.jsx
+++ b/packages/frontend/src/components/download_snarks.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+import { fetchCircuit, fetchProvingKey } from '../utils/fetch'
+
+const formatMB = rawSize => (rawSize / 1024 / 1024).toFixed(2)
+
+const ProgressBar = ({ label, progress }) => {
+  const percentage = progress ? progress.percentage : 0
+
+  const detail =
+    progress && progress.transferred && progress.total
+      ? `${formatMB(progress.transferred)}/${formatMB(progress.total)} MB`
+      : progress && progress.transferred
+      ? `Downloaded ${formatMB(progress.transferred)} MB`
+      : ''
+
+  return (
+    <>
+      <div className='level'>
+        <div className='level-left'>
+          <div className='level-item'>
+            <span className='tag'>{label}</span>
+          </div>
+        </div>
+        <div className='level-right'>
+          <div className='level-item'>
+            <p>{detail}</p>
+          </div>
+        </div>
+      </div>
+      <progress className='progress' value={percentage} max='100'></progress>
+    </>
+  )
+}
+
+const DownloadSnarks = ({ onComplete }) => {
+  const [on, toggle] = useState(true)
+  const [circuitProgress, setCircuitProgress] = useState(null)
+  const [provingKeyProgress, setProvingKeyProgress] = useState(null)
+
+  const startDownload = async () => {
+    toggle(false)
+    await Promise.all([
+      fetchCircuit(progress => setCircuitProgress(progress)),
+      fetchProvingKey(progress => setProvingKeyProgress(progress))
+    ])
+    toggle(true)
+    onComplete()
+  }
+
+  return (
+    <>
+      <p>
+        To use the snark magic, we'll have to download a circuit and proving
+        key. These are public and has a total size 200 MB -ish.
+      </p>
+      <ProgressBar label={'Circuit'} progress={circuitProgress} />
+      <ProgressBar label={'Proving Key'} progress={provingKeyProgress} />
+      <hr />
+      <button
+        className={`button is-primary ${on ? '' : 'is-loading'}`}
+        onClick={startDownload}
+      >
+        Fetch Now
+      </button>
+    </>
+  )
+}
+
+export default DownloadSnarks

--- a/packages/frontend/src/pages/group.jsx
+++ b/packages/frontend/src/pages/group.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import { useWeb3Context } from 'web3-react'
 
-import { NewPost } from './posts'
-import { Posts } from './posts'
+import { NewPost, Posts } from './posts'
+import DownloadSnarks from '../components/download_snarks'
 import { fetchGetRegistrationInfo } from '../utils/fetch'
 import { checkRegistered } from '../web3/registration'
 import { useToasts } from 'react-toast-notifications'
@@ -31,6 +31,10 @@ const Group = () => {
   })
   const [contract, setContract] = useState(null)
   const [newPostId, setNewPostId] = useState(null)
+
+  const [snarksDownloaded, setSnarksDownloaded] = useState(
+    window.circuit && window.provingKey
+  )
 
   useEffect(() => {
     let didCancel = false
@@ -84,6 +88,11 @@ const Group = () => {
       })
     }
   }
+
+  const onSnarkDownloaded = () => {
+    addToast('Circuit and proving key downloaded', { appearance: 'success' })
+    setSnarksDownloaded(true)
+  }
   const onPublish = result => {
     console.log(result)
     if (!result.error) {
@@ -96,14 +105,16 @@ const Group = () => {
     onboarding = <CreateIdentity onCreated={onIdCreated} />
   } else if (!context.active) {
     onboarding = <Activation />
-  } else if (contract !== null) {
+  } else if (contract !== null && !isRegistered) {
     onboarding = <Registration contract={contract} register={_register} />
+  } else if (!snarksDownloaded) {
+    onboarding = <DownloadSnarks onComplete={onSnarkDownloaded} />
   } else {
     onboarding = <p>Loading</p>
   }
   return (
     <div className='container'>
-      {isRegistered ? (
+      {isRegistered && snarksDownloaded ? (
         <NewPost
           contract={contract}
           registrationInfo={registrationInfo}

--- a/packages/frontend/src/utils/fetch.js
+++ b/packages/frontend/src/utils/fetch.js
@@ -1,3 +1,9 @@
+import {
+  CIRCUIT_URL,
+  PROVING_KEY_URL
+} from 'semaphore-auth-contracts/constants'
+import fetchProgress from 'fetch-progress'
+
 const ROOT_URL = 'http://localhost:5566'
 
 const _fetch = async (path, options) => {
@@ -21,4 +27,36 @@ const fetchPostNewPost = async (postBody, proof, publicSignals) => {
   return await _fetch('./posts/new', options)
 }
 
-export { fetchGetPosts, fetchPostNewPost, fetchGetRegistrationInfo }
+import { genCircuit } from 'libsemaphore'
+
+const fetchWithProgress = async (url, onProgress) => {
+  // onProgress takes an argument progress that looks like
+  // {
+  //   total: 132115842,
+  //   transferred: 131596288,
+  //   speed: 131596288,
+  //   eta: 3948090.0859452817,
+  //   remaining: 519554,
+  //   percentage: 100
+  // }
+  return await fetch(url).then(fetchProgress({ onProgress }))
+}
+
+const fetchCircuit = async onProgress => {
+  const response = await fetchWithProgress(CIRCUIT_URL, onProgress)
+  const result = await response.json()
+  window.circuit = genCircuit(result)
+}
+const fetchProvingKey = async onProgress => {
+  const response = await fetchWithProgress(PROVING_KEY_URL, onProgress)
+  const result = await response.arrayBuffer()
+  window.provingKey = new Uint8Array(result)
+}
+
+export {
+  fetchGetPosts,
+  fetchPostNewPost,
+  fetchGetRegistrationInfo,
+  fetchCircuit,
+  fetchProvingKey
+}

--- a/packages/frontend/src/web3/semaphore.js
+++ b/packages/frontend/src/web3/semaphore.js
@@ -1,5 +1,4 @@
 import {
-  genCircuit,
   genExternalNullifier,
   genWitness,
   genProof,
@@ -7,13 +6,7 @@ import {
   stringifyBigInts
 } from 'libsemaphore'
 
-import {
-  SEMAPHORE_TREE_DEPTH,
-  CIRCUIT_URL,
-  PROVING_KEY_URL
-} from 'semaphore-auth-contracts/constants'
-
-const fetchWithoutCache = url => fetch(url, { cache: 'no-store' })
+import { SEMAPHORE_TREE_DEPTH } from 'semaphore-auth-contracts/constants'
 
 const genAuth = async (
   externalNullifierStr,
@@ -22,32 +15,14 @@ const genAuth = async (
   contract,
   progressCallback
 ) => {
-  console.log('Downloading circuit')
-  progressCallback({ text: 'Downloading circuit and proving key ...' })
+  const circuit = window.circuit
+  const provingKey = window.provingKey
 
-  const t0 = performance.now()
-
-  const [cirDef, provingKey] = await Promise.all([
-    fetchWithoutCache(CIRCUIT_URL)
-      .then(res => res.json())
-      .then(res => res),
-    fetchWithoutCache(PROVING_KEY_URL)
-      .then(res => res.arrayBuffer())
-      .then(res => new Uint8Array(res))
-  ])
-
-  const downloadTime = ((performance.now() - t0) / 1000).toFixed(2)
-
-  progressCallback({
-    text: `
-    Circuit and proving key downloaded (${downloadTime} s).
-    Generating Witness ...`
-  })
-
-  const circuit = genCircuit(cirDef)
   const leaves = await contract.getIdentityCommitments()
 
   const externalNullifier = genExternalNullifier(externalNullifierStr)
+
+  progressCallback({ text: 'Generating Witness ...' })
 
   const t1 = performance.now()
   const { witness } = await genWitness(

--- a/packages/frontend/src/web3/semaphore.js
+++ b/packages/frontend/src/web3/semaphore.js
@@ -28,10 +28,10 @@ const genAuth = async (
   const t0 = performance.now()
 
   const [cirDef, provingKey] = await Promise.all([
-    fetchWithoutCache('http://localhost:5566/circuit')
+    fetchWithoutCache(CIRCUIT_URL)
       .then(res => res.json())
       .then(res => res),
-    fetchWithoutCache('http://localhost:5566/provingKey')
+    fetchWithoutCache(PROVING_KEY_URL)
       .then(res => res.arrayBuffer())
       .then(res => new Uint8Array(res))
   ])


### PR DESCRIPTION

- Adding a download interface. 
   - before: Downloading snarks every time when publishing a post/generating a proof. Downloading takes 30 seconds ...
   - this pr: Downloading snarks once per browsing session. 
   - future: Ideally we should cache snarks in browser, so no need to download every time you refresh.
<img width="829" alt="Screen Shot 2020-03-18 at 9 37 12 PM" src="https://user-images.githubusercontent.com/3391420/76966683-51013800-6961-11ea-85cf-23f074550667.png">

- Showing how much time an operation takes. So far 3 seconds on generating witness and 13 seconds for proof.
<img width="1089" alt="Screen Shot 2020-03-18 at 9 41 39 PM" src="https://user-images.githubusercontent.com/3391420/76966692-53fc2880-6961-11ea-8efe-bb2da09c2d56.png">
