### PR TITLE
External nullifier

### DIFF
--- a/packages/backend/src/authentication.js
+++ b/packages/backend/src/authentication.js
@@ -6,8 +6,6 @@ const {
   validateProof
 } = require('./validation')
 
-const configs = require('./configs')
-
 const {
   EpochbasedExternalNullifier
 } = require('semaphore-auth-contracts/lib/externalNullifier')
@@ -17,7 +15,6 @@ const { unstringifyBigInts } = require('libsemaphore')
 const { SemaphoreLog } = require('./schema')
 
 const newPostExternalNullifierGen = new EpochbasedExternalNullifier(
-  configs.SERVER_NAME,
   '/posts/new',
   300 * 1000 // rate limit to 30 seconds
 )
@@ -37,7 +34,7 @@ const requireSemaphoreAuth = async (req, res, next) => {
   ] = parsedPublicSignals
   const content = req.body.postBody
 
-  const expectedExternalNullifierStr = newPostExternalNullifierGen.toString()
+  const expectedExternalNullifierStr = newPostExternalNullifierGen.getString()
 
   try {
     validateExternalNullifierMatch(

--- a/packages/backend/test/backend.test.js
+++ b/packages/backend/test/backend.test.js
@@ -44,12 +44,11 @@ test('should post a new post', async t => {
   const signalStr = ethers.utils.hashMessage(postBody)
 
   const newPostExternalNullifierGen = new EpochbasedExternalNullifier(
-    configs.SERVER_NAME,
     '/posts/new',
     300 * 1000 // rate limit to 30 seconds
   )
 
-  const externalNullifierStr = newPostExternalNullifierGen.toString()
+  const externalNullifierStr = newPostExternalNullifierGen.getString()
   console.log(externalNullifierStr)
   const externalNullifier = libsemaphore.genExternalNullifier(
     externalNullifierStr

--- a/packages/contracts/lib/externalNullifier.js
+++ b/packages/contracts/lib/externalNullifier.js
@@ -1,14 +1,21 @@
 class EpochbasedExternalNullifier {
-  constructor (serviceName, uri, epochLength) {
-    this.serviceName = serviceName
-    this.uri = uri
+  constructor (prefix, epochLength) {
+    this.prefix = prefix
     this.epochLength = epochLength // In milliseconds
   }
 
-  toString () {
+  epochStart () {
     const now = new Date().valueOf()
-    const epochStart = now - (now % this.epochLength)
-    return `${this.serviceName}:${this.uri}:${epochStart}`
+    return now - (now % this.epochLength)
+  }
+
+  timeBeforeNextEpoch () {
+    const now = new Date().valueOf()
+    return this.epochLength - (now % this.epochLength)
+  }
+
+  getString () {
+    return `${this.prefix}:${this.epochStart()}`
   }
 }
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,6 +25,7 @@
     "fetch-progress": "^1.2.0",
     "libsemaphore": "1.0.14",
     "react": "^16.8",
+    "react-countdown-circle-timer": "^1.1.1",
     "react-dom": "^16.8",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,13 +22,14 @@
     "bulma": "^0.8.0",
     "dotenv": "^8.2.0",
     "ethers": "^4",
+    "fetch-progress": "^1.2.0",
     "libsemaphore": "1.0.14",
     "react": "^16.8",
     "react-dom": "^16.8",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-toast-notifications": "^2.4.0",
-    "semaphore-auth-contracts": "file:../contracts",
+    "semaphore-auth-contracts": "file:../contracts/",
     "web3-react": "^5.0.5"
   }
 }

--- a/packages/frontend/src/pages/group.jsx
+++ b/packages/frontend/src/pages/group.jsx
@@ -115,11 +115,7 @@ const Group = () => {
   return (
     <div className='container'>
       {isRegistered && snarksDownloaded ? (
-        <NewPost
-          contract={contract}
-          registrationInfo={registrationInfo}
-          onPublish={onPublish}
-        />
+        <NewPost contract={contract} onPublish={onPublish} />
       ) : (
         onboarding
       )}


### PR DESCRIPTION
- Redefine the interface a little bit. Now we hard code the external nullifier generator in backend and frontend, we can prevent passing data around. In the future, we can make the external nullifier generator more configurable. So maybe web host, group owner, or developers can customize their own needs. 
- Add a countdown to indicate users to publish the article before the end of the epoch.
<img width="660" alt="Screen Shot 2020-03-18 at 11 51 18 PM" src="https://user-images.githubusercontent.com/3391420/76979889-89117680-6973-11ea-84a5-db36b6ec612b.png">
